### PR TITLE
feat: add tflops and tokens per second info for gpt pretraining

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -16,7 +16,13 @@
 # To suppress BF16 compile related issue in the CI runs with turing/V100
 import torch._dynamo
 import torch.multiprocessing as mp
+
 from omegaconf.omegaconf import OmegaConf, open_dict
+from typing import Dict, Any, Optional, Union
+from argparse import Namespace
+
+from pytorch_lightning.loggers import Logger
+from pytorch_lightning.utilities import rank_zero_only
 
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
 from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronTrainerBuilder
@@ -24,10 +30,143 @@ from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
+try:
+    from megatron.core import parallel_state
+
+    HAVE_MEGATRON_CORE = True
+
+except (ImportError, ModuleNotFoundError):
+
+    HAVE_MEGATRON_CORE = False
+
+try:
+    from apex import amp
+    from apex.transformer.enums import AttnMaskType
+    from apex.transformer.pipeline_parallel.utils import get_num_microbatches
+
+    HAVE_APEX = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_APEX = False
+
 torch._dynamo.config.suppress_errors = True
 
 mp.set_start_method("spawn", force=True)
 
+def calculate_model_size(
+    vocab_size: int = None,
+    seq_length: int = None,
+    hidden_size: int = None,
+    num_layers: int = None,
+    ffn_size: int = None,
+    att_heads: int = None,
+    model_name: str = "gpt3",
+):
+    model_size = (
+        12
+        * num_layers
+        * hidden_size ** 2
+        * (1 + (13 / (12 * hidden_size)) + ((vocab_size + seq_length) / (12 * num_layers * hidden_size)))
+        / 1e9
+    )
+    return model_size
+
+def throughput_calculator(model, cfg, iteration_time, total_iterations):
+    if total_iterations == 0.0:
+        return 0, 0, 0
+    world_size = torch.distributed.get_world_size()
+    micro_batch_size = cfg.model.micro_batch_size
+    data_parallel_size = parallel_state.get_data_parallel_world_size()
+    batch_size = micro_batch_size * get_num_microbatches() * data_parallel_size
+    samples_per_model = batch_size * cfg.model.data.seq_length
+
+    hidden_size = cfg.model.hidden_size
+    num_layers = cfg.model.num_layers
+    vocab_size = model.padded_vocab_size
+    ffn_hidden_size = cfg.model.ffn_hidden_size
+    att_heads = cfg.model.num_attention_heads
+    model_size = calculate_model_size(vocab_size, cfg.model.data.seq_length, hidden_size, num_layers, ffn_hidden_size, att_heads)
+
+    samples_per_second = batch_size / iteration_time
+
+    #flops calculator
+    # General TFLOPs formula (borrowed from Equation 3 in Section 5.1 of
+    # https://arxiv.org/pdf/2104.04473.pdf).
+    # The factor of 4 is when used with activation check-pointing,
+    # otherwise it will be 3.
+    checkpoint_activations_factor = 3
+    if cfg.model.activations_checkpoint_granularity == 'selective':
+            checkpoint_activations_factor = 4
+    seq_len = cfg.model.data.seq_length
+    flops_per_iteration = (24 * checkpoint_activations_factor * batch_size * seq_len * num_layers * (hidden_size**2)) * (1. + (seq_len / (6. * hidden_size)) + (vocab_size / (16. * num_layers * hidden_size)))
+    tflops = flops_per_iteration / (iteration_time * world_size * (10**12))
+    return samples_per_second, tflops, model_size
+
+# ref: https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.loggers.logger.html#lightning.pytorch.loggers.logger.Logger
+
+class MetricsLogger(TensorBoardLogger):
+    def __init__(self, trainer, model, cfg,
+                 train_loss_key='reduced_train_loss', val_loss_key='val_loss',
+                 timing_keys=('train_step_timing', 'train_epoch_timing', 'validation_step_timing', 'validation_epoch_timing'),
+                 throughput_key='train_epoch_timing'):
+        super().__init__()
+        self.trainer = trainer
+        self.model = model
+        self.cfg = cfg
+        self.val_loss_key = val_loss_key
+        self.train_loss_key = train_loss_key
+        self.timing_keys = timing_keys
+        self.throughput_key = throughput_key
+        self.target_val_log_ppl = 10.82
+        self._experiment = None
+
+    def log_metrics(self, metrics: Dict[str, float],
+                    step: Optional[int] = None) -> None:
+        if "validation_step_timing" in metrics:
+            elapsed_time = metrics["validation_step_timing"]
+            log_string = ' Step {}/{}: |'.format(step, self.trainer.num_val_batches)
+            log_string += ' validation_step_timing {:.2f}: |'.format(metrics["validation_step_timing"])
+        elif "train_step_timing" in metrics:
+            elapsed_time = metrics["train_step_timing"]
+            total_iterations = metrics["global_step"]
+            samples_per_sec, tflops, approx_parameters_in_billions = throughput_calculator(self.model, self.cfg, elapsed_time, total_iterations)
+            tokens_per_sec = samples_per_sec * self.cfg.model.data.seq_length
+
+            log_string = ' Epoch {}: iteration {}/{} |'.format(metrics["epoch"], self.trainer.global_step, self.trainer.max_steps)
+            log_string += ' train_step_timing (s): {:.2f} |'.format(metrics["train_step_timing"])
+            # log_string += ' global_step: {} |'.format(metrics["global_step"])
+            log_string += ' reduced_train_loss: {:.2f} |'.format(metrics["reduced_train_loss"])
+            log_string += ' lr: {:.3E} |'.format(metrics["lr"])
+            log_string += ' consumed samples: {} |'.format(metrics["consumed_samples"])
+            log_string += ' samples per sec: {:.2f} |'.format(samples_per_sec)
+            log_string += ' tokens per sec: {:.2f} |'.format(tokens_per_sec)
+            log_string += ' TFLOPs: {:.2f} |'.format(tflops)
+            log_string += ' Model Size(B): {:.2f} |'.format(approx_parameters_in_billions)
+            log_string += ' Global Batch Size: {} |'.format(self.cfg.model.global_batch_size)
+            log_string += ' Micro Batch Size: {}'.format(self.cfg.model.micro_batch_size)
+            # log_string += ' loss_scale: {:1f} |'.format(metrics["loss_scale"])
+            # log_string += ' train_backward_timing: {:.2f} |'.format(metrics["train_backward_timing"])
+            # log_string += ' grad_norm: {:.2f}'.format(metrics["grad_norm"])
+        else:
+            log_string = str(metrics)
+        logging.info(log_string)
+
+    @rank_zero_only
+    def log_hyperparams(self, params: Union[Dict[str, Any], Namespace],
+                        *args: Any, **kwargs: Any) -> None:
+        model_cfg = params.cfg
+ 
+    @property
+    def name(self) -> Optional[str]:
+        return 'nemo-metrics-logger'
+
+    @property
+    def version(self) -> Optional[Union[int, str]]:
+        return 1
+    
+    @property
+    def experiment(self):
+        """Return the experiment object associated with this logger."""
+        return "experiment"
 
 @hydra_runner(config_path="conf", config_name="megatron_gpt_config")
 def main(cfg) -> None:
@@ -39,6 +178,7 @@ def main(cfg) -> None:
 
     model = MegatronGPTModel(cfg.model, trainer)
 
+    trainer.loggers.append(MetricsLogger(trainer, model, cfg))
     trainer.fit(model)
 
 

--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -125,14 +125,14 @@ class MetricsLogger(TensorBoardLogger):
             elapsed_time = metrics["validation_step_timing"]
             log_string = ' Step {}/{}: |'.format(step, self.trainer.num_val_batches)
             log_string += ' validation_step_timing {:.2f}: |'.format(metrics["validation_step_timing"])
-        elif "train_step_timing" in metrics:
-            elapsed_time = metrics["train_step_timing"]
+        elif "train_step_timing in s" in metrics:
+            elapsed_time = metrics["train_step_timing in s"]
             total_iterations = metrics["global_step"]
             samples_per_sec, tflops, approx_parameters_in_billions = throughput_calculator(self.model, self.cfg, elapsed_time, total_iterations)
             tokens_per_sec = samples_per_sec * self.cfg.model.data.seq_length
 
             log_string = ' Epoch {}: iteration {}/{} |'.format(metrics["epoch"], self.trainer.global_step, self.trainer.max_steps)
-            log_string += ' train_step_timing (s): {:.2f} |'.format(metrics["train_step_timing"])
+            log_string += ' train_step_timing (s): {:.2f} |'.format(metrics["train_step_timing in s"])
             # log_string += ' global_step: {} |'.format(metrics["global_step"])
             log_string += ' reduced_train_loss: {:.2f} |'.format(metrics["reduced_train_loss"])
             log_string += ' lr: {:.3E} |'.format(metrics["lr"])

--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -103,7 +103,7 @@ def throughput_calculator(model, cfg, iteration_time, total_iterations):
 
 # ref: https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.loggers.logger.html#lightning.pytorch.loggers.logger.Logger
 
-class MetricsLogger(TensorBoardLogger):
+class MetricsLogger(Logger):
     def __init__(self, trainer, model, cfg,
                  train_loss_key='reduced_train_loss', val_loss_key='val_loss',
                  timing_keys=('train_step_timing', 'train_epoch_timing', 'validation_step_timing', 'validation_epoch_timing'),


### PR DESCRIPTION
# What does this PR do ?

add tflops and tokens per second info for gpt pretraining via using customized logger

**Collection**: [Note which collection this PR will affect]

# Changelog 
- add tflops and tokens per second info for gpt pretraining via using customized logger

# Usage
* When pretraining GPT using NeMo examples, it would print tflops infomation

```bash
python /data/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py  \
    --config-path=/data/NeMo/examples/nlp/language_modeling/conf \
    --config-name=megatron_gpt_config \
    trainer.devices=8 \
    trainer.num_nodes=1 \
    trainer.max_epochs=null \
    trainer.max_steps=300000 \
    trainer.val_check_interval=300 \
    trainer.log_every_n_steps=50 \
    trainer.limit_val_batches=50 \
    trainer.limit_test_batches=50 \
    trainer.accumulate_grad_batches=1 \
    trainer.precision=bf16 \
    model.micro_batch_size=1 \
    model.global_batch_size=256 \
    model.tensor_model_parallel_size=4 \
    model.pipeline_model_parallel_size=1 \
    model.sequence_parallel=True \
    model.max_position_embeddings=2048 \
    model.encoder_seq_length=2048 \
    model.hidden_size=2048 \
    model.ffn_hidden_size=5440 \
    model.num_layers=24 \
    model.num_attention_heads=16 \
    model.init_method_std=0.014 \
    model.hidden_dropout=0.0 \
    model.attention_dropout=0.0 \
    model.layernorm_epsilon=1e-5 \
    model.apply_query_key_layer_scaling=True \
    model.normalization=layernorm1p \
    model.bias=True \
    model.activation=fast-swiglu \
    model.position_embedding_type=rope \
    model.rotary_percentage=0.5 \
    model.share_embeddings_and_output_weights=False \
    model.tokenizer.vocab_file=gpt2-vocab.json \
    model.tokenizer.merge_file=gpt2-merges.txt \
    model.megatron_amp_O2=True \
    model.bias_activation_fusion=False \
    model.bias_dropout_add_fusion=False \
    model.data.data_prefix=[1.0,hfbpe_gpt_training_data_text_document] \
    model.data.num_workers=2 \
    model.data.seq_length=4096 \
    model.data.splits_string=\'980,10,10\' \
    model.optim.name=distributed_fused_adam \
    model.optim.lr=2e-4 \
    model.optim.betas=[0.9,0.95] \
    model.optim.weight_decay=0.1 \
    model.optim.sched.name=CosineAnnealing \
    model.optim.sched.warmup_steps=500 \
    model.optim.sched.constant_steps=0 \
    model.optim.sched.min_lr=2e-5 \
    exp_manager.resume_if_exists=True \
    exp_manager.resume_ignore_no_checkpoint=True \
    exp_manager.create_checkpoint_callback=True \
    exp_manager.checkpoint_callback_params.monitor=val_loss \
    exp_manager.checkpoint_callback_params.save_top_k=3 \
    exp_manager.checkpoint_callback_params.mode=min \
    exp_manager.checkpoint_callback_params.always_save_nemo=False
```

```
Epoch 0: :   0%|                                                                                 | 50/301500 [05:51<589:13:24, v_num=0_1, reduced_train_loss=7.780, global_step=49.00, consumed_samples=12800.0, train_step_timing in s=6.810]
[NeMo I 2024-03-02 02:39:58 megatron_gpt_pretraining:151]  Epoch 0: iteration 50/300000 | train_step_timing (s): 6.81 | reduced_train_loss: 7.78 | lr: 1.996E-05 | consumed samples: 12800.0 | samples per sec: 37.58 | tokens per sec: 76962.87 | TFLOPs: 85.81 | Model Size(B): 1.32 | Global Batch Size: 256 | Micro Batch Size: 1
```

# Jenkins CI
No modification on Jenkins CI

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
